### PR TITLE
Enables e-mail batching in the scheduler

### DIFF
--- a/luigi/batch_notifier.py
+++ b/luigi/batch_notifier.py
@@ -1,0 +1,206 @@
+"""
+Library for sending batch notifications from the Luigi scheduler. This module
+is internal to Luigi and not designed for use in other contexts.
+"""
+
+import collections
+from datetime import datetime
+import time
+
+import luigi
+from luigi import six
+from luigi.notifications import send_email, email
+import luigi.parameter
+
+
+class batch_email(luigi.Config):
+    email_interval = luigi.parameter.IntParameter(
+        default=60, description='Number of minutes between e-mail sends (default: 60)')
+    batch_mode = luigi.parameter.ChoiceParameter(
+        default='unbatched_params', choices=('family', 'all', 'unbatched_params'),
+        description='Method used for batching failures in e-mail. If "family" all failures for '
+                    'tasks with the same family will be batched. If "unbatched_params", all '
+                    'failures for tasks with the same family and non-batched parameters will be '
+                    'batched. If "all", tasks will only be batched if they have identical names.')
+    error_lines = luigi.parameter.IntParameter(
+        default=20, description='Number of lines to show from each error message. 0 means show all')
+    error_messages = luigi.parameter.IntParameter(
+        default=1, description='Number of error messages to show for each group')
+    group_by_error_messages = luigi.parameter.BoolParameter(
+        default=True, description='Group items with the same error messages together')
+
+
+class ExplQueue(collections.OrderedDict):
+    def __init__(self, num_items):
+        self.num_items = num_items
+        super(ExplQueue, self).__init__()
+
+    def enqueue(self, item):
+        self.pop(item, None)
+        self[item] = datetime.now()
+        if len(self) > self.num_items:
+            self.popitem(last=False)  # pop first item if past length
+
+
+def _fail_queue(num_messages):
+    return lambda: collections.defaultdict(lambda: ExplQueue(num_messages))
+
+
+def _plural_format(template, number, plural='s'):
+    if number == 0:
+        return ''
+    return template.format(number, '' if number == 1 else plural)
+
+
+class BatchNotifier(object):
+    def __init__(self, **kwargs):
+        self._config = batch_email(**kwargs)
+        self._fail_counts = collections.defaultdict(collections.Counter)
+        self._disabled_counts = collections.defaultdict(collections.Counter)
+        self._scheduling_fail_counts = collections.defaultdict(collections.Counter)
+        self._fail_expls = collections.defaultdict(_fail_queue(self._config.error_messages))
+        self._update_next_send()
+
+        self._email_format = email().format
+        if email().receiver:
+            self._default_owner = set(filter(None, email().receiver.split(',')))
+        else:
+            self._default_owner = set()
+
+    def _update_next_send(self):
+        self._next_send = time.time() + 60 * self._config.email_interval
+
+    def _key(self, task_name, family, unbatched_args):
+        if self._config.batch_mode == 'all':
+            return task_name
+        elif self._config.batch_mode == 'family':
+            return family
+        elif self._config.batch_mode == 'unbatched_params':
+            param_str = six.u(', ').join(six.u('{}={}').format(*kv) for kv in six.iteritems(unbatched_args))
+            return six.u('{}({})').format(family, param_str)
+        else:
+            raise ValueError('Unknown batch mode for batch notifier: {}'.format(
+                self._config.batch_mode))
+
+    def _format_expl(self, expl):
+        lines = expl.rstrip().split('\n')[-self._config.error_lines:]
+        if self._email_format == 'html':
+            return six.u('<pre>{}</pre>').format('\n'.join(lines))
+        else:
+            return six.u('\n{}').format(six.u('\n').join(map(six.u('      {}').format, lines)))
+
+    def _expl_body(self, expls):
+        lines = [self._format_expl(expl) for expl in expls]
+        if lines and self._email_format != 'html':
+            lines.append('')
+        return '\n'.join(lines)
+
+    def _format_task(self, task_tuple):
+        task, failure_count, disable_count, scheduling_count = task_tuple
+        counts = [
+            _plural_format('{} failure{}', failure_count),
+            _plural_format('{} disable{}', disable_count),
+            _plural_format('{} scheduling failure{}', scheduling_count),
+        ]
+        count_str = six.u(', ').join(filter(None, counts))
+        return six.u('{} ({})').format(task, count_str)
+
+    def _format_tasks(self, tasks):
+        lines = map(self._format_task, sorted(tasks, key=self._expl_key))
+        if self._email_format == 'html':
+            return six.u('<li>{}').format(six.u('\n<br>').join(lines))
+        else:
+            return six.u('- {}').format(six.u('\n  ').join(lines))
+
+    def _owners(self, owners):
+        return self._default_owner | set(owners)
+
+    def add_failure(self, task_name, family, unbatched_args, expl, owners):
+        key = self._key(task_name, family, unbatched_args)
+        for owner in self._owners(owners):
+            self._fail_counts[owner][key] += 1
+            self._fail_expls[owner][key].enqueue(expl)
+
+    def add_disable(self, task_name, family, unbatched_args, owners):
+        key = self._key(task_name, family, unbatched_args)
+        for owner in self._owners(owners):
+            self._disabled_counts[owner][key] += 1
+            self._fail_counts[owner].setdefault(key, 0)
+
+    def add_scheduling_fail(self, task_name, family, unbatched_args, expl, owners):
+        key = self._key(task_name, family, unbatched_args)
+        for owner in self._owners(owners):
+            self._scheduling_fail_counts[owner][key] += 1
+            self._fail_expls[owner][key].enqueue(expl)
+            self._fail_counts[owner].setdefault(key, 0)
+
+    def _task_expl_groups(self, expls):
+        if not self._config.group_by_error_messages:
+            return [((task,), msg) for task, msg in six.iteritems(expls)]
+
+        groups = collections.defaultdict(list)
+        for task, msg in six.iteritems(expls):
+            groups[msg].append(task)
+        return [(tasks, msg) for msg, tasks in six.iteritems(groups)]
+
+    def _expls_key(self, expls_tuple):
+        expls = expls_tuple[0]
+        num_failures = sum(failures + scheduling_fails for (_1, failures, _2, scheduling_fails) in expls)
+        num_disables = sum(disables for (_1, _2, disables, _3) in expls)
+        min_name = min(expls)[0]
+        return -num_failures, -num_disables, min_name
+
+    def _expl_key(self, expl):
+        return self._expls_key(((expl,), None))
+
+    def _email_body(self, fail_counts, disable_counts, scheduling_counts, fail_expls):
+        expls = {
+            (name, fail_count, disable_counts[name], scheduling_counts[name]): self._expl_body(fail_expls[name])
+            for name, fail_count in six.iteritems(fail_counts)
+        }
+        expl_groups = sorted(self._task_expl_groups(expls), key=self._expls_key)
+        body_lines = []
+        for tasks, msg in expl_groups:
+            body_lines.append(self._format_tasks(tasks))
+            body_lines.append(msg)
+        body = six.u('\n').join(filter(None, body_lines)).rstrip()
+        if self._email_format == 'html':
+            return six.u('<ul>\n{}\n</ul>').format(body)
+        else:
+            return body
+
+    def _send_email(self, fail_counts, disable_counts, scheduling_counts, fail_expls, owner):
+        num_failures = sum(six.itervalues(fail_counts))
+        num_disables = sum(six.itervalues(disable_counts))
+        num_scheduling_failures = sum(six.itervalues(scheduling_counts))
+        subject_parts = [
+            _plural_format('{} failure{}', num_failures),
+            _plural_format('{} disable{}', num_disables),
+            _plural_format('{} scheduling failure{}', num_scheduling_failures),
+        ]
+        subject_base = ', '.join(filter(None, subject_parts))
+        if subject_base:
+            prefix = '' if owner in self._default_owner else 'Your tasks have '
+            subject = 'Luigi: {}{} in the last {} minutes'.format(
+                prefix, subject_base, self._config.email_interval)
+            email_body = self._email_body(fail_counts, disable_counts, scheduling_counts, fail_expls)
+            send_email(subject, email_body, email().sender, (owner,))
+
+    def send_email(self):
+        for owner, failures in six.iteritems(self._fail_counts):
+            self._send_email(
+                fail_counts=failures,
+                disable_counts=self._disabled_counts[owner],
+                scheduling_counts=self._scheduling_fail_counts[owner],
+                fail_expls=self._fail_expls[owner],
+                owner=owner,
+            )
+        self._update_next_send()
+        self._fail_counts.clear()
+        self._disabled_counts.clear()
+        self._scheduling_fail_counts.clear()
+        self._fail_expls.clear()
+
+    def update(self):
+        if time.time() >= self._next_send:
+            self.send_email()

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -23,6 +23,9 @@ See :doc:`/central_scheduler` for more info.
 
 import collections
 import inspect
+import json
+
+from luigi.batch_notifier import BatchNotifier
 
 try:
     import cPickle as pickle
@@ -124,6 +127,8 @@ class scheduler(Config):
     remove_delay = parameter.FloatParameter(default=600.0)
     worker_disconnect_delay = parameter.FloatParameter(default=60.0)
     state_path = parameter.Parameter(default='/var/lib/luigi-server/state.pickle')
+
+    batch_emails = parameter.BoolParameter(default=False, description="Send e-mails in batches rather than immediately")
 
     # Jobs are disabled if we see more than retry_count failures in disable_window seconds.
     # These disables last for disable_persist seconds.
@@ -329,7 +334,7 @@ class Task(object):
 
     @property
     def pretty_id(self):
-        param_str = ', '.join('{}={}'.format(key, value) for key, value in self.params.items())
+        param_str = ', '.join('{}={}'.format(key, value) for key, value in sorted(self.params.items()))
         return '{}({})'.format(self.family, param_str)
 
 
@@ -543,15 +548,16 @@ class SimpleTaskState(object):
             if task.has_excessive_failures():
                 task.scheduler_disable_time = time.time()
                 new_status = DISABLED
-                notifications.send_error_email(
-                    'Luigi Scheduler: DISABLED {task} due to excessive failures'.format(task=task.id),
-                    '{task} failed {failures} times in the last {window} seconds, so it is being '
-                    'disabled for {persist} seconds'.format(
-                        failures=task.retry_policy.retry_count,
-                        task=task.id,
-                        window=config.disable_window,
-                        persist=config.disable_persist,
-                    ))
+                if not config.batch_emails:
+                    notifications.send_error_email(
+                        'Luigi Scheduler: DISABLED {task} due to excessive failures'.format(task=task.id),
+                        '{task} failed {failures} times in the last {window} seconds, so it is being '
+                        'disabled for {persist} seconds'.format(
+                            failures=task.retry_policy.retry_count,
+                            task=task.id,
+                            window=config.disable_window,
+                            persist=config.disable_persist,
+                        ))
         elif new_status == DISABLED:
             task.scheduler_disable_time = None
 
@@ -670,17 +676,23 @@ class Scheduler(object):
         self._make_task = functools.partial(Task, retry_policy=self._config._get_retry_policy())
         self._worker_requests = {}
 
+        if self._config.batch_emails:
+            self._email_batcher = BatchNotifier()
+
     def load(self):
         self._state.load()
 
     def dump(self):
         self._state.dump()
+        if self._config.batch_emails:
+            self._email_batcher.send_email()
 
     @rpc_method()
     def prune(self):
         logger.info("Starting pruning of task graph")
         self._prune_workers()
         self._prune_tasks()
+        self._prune_emails()
         logger.info("Done pruning task graph")
 
     def _prune_workers(self):
@@ -704,6 +716,10 @@ class Scheduler(object):
                 remove_tasks.append(task.id)
 
         self._state.inactivate_tasks(remove_tasks)
+
+    def _prune_emails(self):
+        if self._config.batch_emails:
+            self._email_batcher.update()
 
     def _update_worker(self, worker_id, worker_reference=None, get_work=False):
         # Keep track of whenever the worker was last active.
@@ -734,7 +750,7 @@ class Scheduler(object):
                  deps=None, new_deps=None, expl=None, resources=None,
                  priority=0, family='', module=None, params=None,
                  assistant=False, tracking_url=None, worker=None, batchable=None,
-                 batch_id=None, retry_policy_dict={}, **kwargs):
+                 batch_id=None, retry_policy_dict={}, owners=None, **kwargs):
         """
         * add task identified by task_id if it doesn't exist
         * if deps is not None, update dependency list
@@ -800,6 +816,27 @@ class Scheduler(object):
                 self._update_task_history(task, status)
             self._state.set_status(task, PENDING if status == SUSPENDED else status, self._config)
 
+        if status == FAILED and self._config.batch_emails:
+            batched_params, _ = self._state.get_batcher(worker_id, family)
+            if batched_params:
+                unbatched_params = {
+                    param: value
+                    for param, value in six.iteritems(task.params)
+                    if param not in batched_params
+                }
+            else:
+                unbatched_params = task.params
+            try:
+                expl_raw = json.loads(expl)
+            except ValueError:
+                expl_raw = expl
+
+            self._email_batcher.add_failure(
+                task.pretty_id, task.family, unbatched_params, expl_raw, owners)
+            if task.status == DISABLED:
+                self._email_batcher.add_disable(
+                    task.pretty_id, task.family, unbatched_params, owners)
+
         if deps is not None:
             task.deps = set(deps)
 
@@ -828,6 +865,22 @@ class Scheduler(object):
             task.workers.add(worker_id)
             self._state.get_worker(worker_id).tasks.add(task)
             task.runnable = runnable
+
+    @rpc_method()
+    def announce_scheduling_failure(self, task_name, family, params, expl, owners, **kwargs):
+        if not self._config.batch_emails:
+            return
+        worker_id = kwargs['worker']
+        batched_params, _ = self._state.get_batcher(worker_id, family)
+        if batched_params:
+            unbatched_params = {
+                param: value
+                for param, value in six.iteritems(params)
+                if param not in batched_params
+            }
+        else:
+            unbatched_params = params
+        self._email_batcher.add_scheduling_fail(task_name, family, unbatched_params, expl, owners)
 
     @rpc_method()
     def add_worker(self, worker, info, **kwargs):

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -191,6 +191,18 @@ class Task(object):
         '''
         return None
 
+    def _owner_list(self):
+        """
+        Turns the owner_email property into a list. This should not be overridden.
+        """
+        owner_email = self.owner_email
+        if owner_email is None:
+            return []
+        elif isinstance(owner_email, six.string_types):
+            return owner_email.split(',')
+        else:
+            return owner_email
+
     @property
     def use_cmdline_section(self):
         ''' Property used by core config such as `--workers` etc.

--- a/test/batch_notifier_test.py
+++ b/test/batch_notifier_test.py
@@ -1,0 +1,562 @@
+# coding=utf-8
+
+import mock
+import unittest
+
+import six
+
+import luigi.batch_notifier
+
+
+BATCH_NOTIFIER_DEFAULTS = {
+    'error_lines': 0,
+    'error_messages': 0,
+    'group_by_error_messages': False,
+}
+
+
+class BatchNotifier(luigi.batch_notifier.BatchNotifier):
+    """BatchNotifier class with defaults that produce smaller output for testing"""
+    def __init__(self, **kwargs):
+        full_args = BATCH_NOTIFIER_DEFAULTS.copy()
+        full_args.update(kwargs)
+        super(BatchNotifier, self).__init__(**full_args)
+
+
+class BatchNotifierTest(unittest.TestCase):
+    def setUp(self):
+        self.time_mock = mock.patch('luigi.batch_notifier.time.time')
+        self.time = self.time_mock.start()
+        self.time.return_value = 0.0
+
+        self.send_email_mock = mock.patch('luigi.batch_notifier.send_email')
+        self.send_email = self.send_email_mock.start()
+
+        self.email_mock = mock.patch('luigi.batch_notifier.email')
+        self.email = self.email_mock.start()
+        self.email().sender = 'sender@test.com'
+        self.email().receiver = 'r@test.com'
+
+    def tearDown(self):
+        self.time_mock.stop()
+        self.send_email_mock.stop()
+        self.email_mock.stop()
+
+    def incr_time(self, minutes):
+        self.time.return_value += minutes * 60
+
+    def check_email_send(self, subject, message, receiver='r@test.com', sender='sender@test.com'):
+        self.send_email.assert_called_once_with(subject, message, sender, (receiver,))
+
+    def test_send_single_failure(self):
+        bn = BatchNotifier(batch_mode='all')
+        bn.add_failure('Task(a=5)', 'Task', {'a': 5}, 'error', [])
+        bn.send_email()
+        self.check_email_send(
+            'Luigi: 1 failure in the last 60 minutes',
+            '- Task(a=5) (1 failure)'
+        )
+
+    def test_do_not_send_single_failure_without_receiver(self):
+        self.email().receiver = None
+        bn = BatchNotifier(batch_mode='all')
+        bn.add_failure('Task(a=5)', 'Task', {'a': 5}, 'error', [])
+        bn.send_email()
+        self.send_email.assert_not_called()
+
+    def test_send_single_failure_to_owner_only(self):
+        self.email().receiver = None
+        bn = BatchNotifier(batch_mode='all')
+        bn.add_failure('Task(a=5)', 'Task', {'a': 5}, 'error', ['owner@test.com'])
+        bn.send_email()
+        self.check_email_send(
+            'Luigi: Your tasks have 1 failure in the last 60 minutes',
+            '- Task(a=5) (1 failure)',
+            receiver='owner@test.com',
+        )
+
+    def test_send_single_disable(self):
+        bn = BatchNotifier(batch_mode='all')
+        for _ in range(10):
+            bn.add_failure('Task(a=5)', 'Task', {'a': 5}, 'error', [])
+        bn.add_disable('Task(a=5)', 'Task', {'a': 5}, [])
+        bn.send_email()
+        self.check_email_send(
+            'Luigi: 10 failures, 1 disable in the last 60 minutes',
+            '- Task(a=5) (10 failures, 1 disable)'
+        )
+
+    def test_send_multiple_disables(self):
+        bn = BatchNotifier(batch_mode='family')
+        for _ in range(10):
+            bn.add_failure('Task(a=5)', 'Task', {'a': 5}, 'error', [])
+            bn.add_failure('Task(a=6)', 'Task', {'a': 6}, 'error', [])
+        bn.add_disable('Task(a=5)', 'Task', {'a': 5}, [])
+        bn.add_disable('Task(a=6)', 'Task', {'a': 6}, [])
+        bn.send_email()
+        self.check_email_send(
+            'Luigi: 20 failures, 2 disables in the last 60 minutes',
+            '- Task (20 failures, 2 disables)'
+        )
+
+    def test_send_single_scheduling_fail(self):
+        bn = BatchNotifier(batch_mode='family')
+        bn.add_scheduling_fail('Task()', 'Task', {}, 'error', [])
+        bn.send_email()
+        self.check_email_send(
+            'Luigi: 1 scheduling failure in the last 60 minutes',
+            '- Task (1 scheduling failure)',
+        )
+
+    def test_multiple_failures_of_same_job(self):
+        bn = BatchNotifier(batch_mode='all')
+        bn.add_failure('Task(a=5)', 'Task', {'a': 5}, 'error', [])
+        bn.add_failure('Task(a=5)', 'Task', {'a': 5}, 'error', [])
+        bn.add_failure('Task(a=5)', 'Task', {'a': 5}, 'error', [])
+        bn.send_email()
+        self.check_email_send(
+            'Luigi: 3 failures in the last 60 minutes',
+            '- Task(a=5) (3 failures)'
+        )
+
+    def test_multiple_failures_of_multiple_jobs(self):
+        bn = BatchNotifier(batch_mode='all')
+        bn.add_failure('Task(a=5)', 'Task', {'a': 5}, 'error', [])
+        bn.add_failure('Task(a=6)', 'Task', {'a': 6}, 'error', [])
+        bn.add_failure('Task(a=6)', 'Task', {'a': 6}, 'error', [])
+        bn.send_email()
+        self.check_email_send(
+            'Luigi: 3 failures in the last 60 minutes',
+            '- Task(a=6) (2 failures)\n'
+            '- Task(a=5) (1 failure)'
+        )
+
+    def test_group_on_family(self):
+        bn = BatchNotifier(batch_mode='family')
+        bn.add_failure('Task(a=5)', 'Task', {'a': 5}, 'error', [])
+        bn.add_failure('Task(a=6)', 'Task', {'a': 6}, 'error', [])
+        bn.add_failure('Task(a=6)', 'Task', {'a': 6}, 'error', [])
+        bn.add_failure('OtherTask(a=6)', 'OtherTask', {'a': 6}, 'error', [])
+        bn.send_email()
+        self.check_email_send(
+            'Luigi: 4 failures in the last 60 minutes',
+            '- Task (3 failures)\n'
+            '- OtherTask (1 failure)'
+        )
+
+    def test_group_on_unbatched_params(self):
+        bn = BatchNotifier(batch_mode='unbatched_params')
+        bn.add_failure('Task(a=5, b=1)', 'Task', {'a': 5}, 'error', [])
+        bn.add_failure('Task(a=5, b=2)', 'Task', {'a': 5}, 'error', [])
+        bn.add_failure('Task(a=6, b=1)', 'Task', {'a': 6}, 'error', [])
+        bn.add_failure('Task(a=6, b=2)', 'Task', {'a': 6}, 'error', [])
+        bn.add_failure('Task(a=6, b=3)', 'Task', {'a': 6}, 'error', [])
+        bn.add_failure('Task(a=6, b=4)', 'Task', {'a': 6}, 'error', [])
+        bn.add_failure('OtherTask(a=5, b=1)', 'OtherTask', {'a': 5}, 'error', [])
+        bn.add_failure('OtherTask(a=6, b=1)', 'OtherTask', {'a': 6}, 'error', [])
+        bn.add_failure('OtherTask(a=6, b=2)', 'OtherTask', {'a': 6}, 'error', [])
+        bn.add_failure('OtherTask(a=6, b=3)', 'OtherTask', {'a': 6}, 'error', [])
+        bn.send_email()
+        self.check_email_send(
+            'Luigi: 10 failures in the last 60 minutes',
+            '- Task(a=6) (4 failures)\n'
+            '- OtherTask(a=6) (3 failures)\n'
+            '- Task(a=5) (2 failures)\n'
+            '- OtherTask(a=5) (1 failure)'
+        )
+
+    def test_include_one_expl_includes_latest(self):
+        bn = BatchNotifier(batch_mode='family', error_messages=1)
+        bn.add_failure('Task(a=1)', 'Task', {'a': 1}, 'error 1', [])
+        bn.add_failure('Task(a=2)', 'Task', {'a': 2}, 'error 2', [])
+        bn.add_failure('TaskB(a=1)', 'TaskB', {'a': 1}, 'error', [])
+
+        bn.send_email()
+        self.check_email_send(
+            'Luigi: 3 failures in the last 60 minutes',
+            '- Task (2 failures)\n'
+            '\n'
+            '      error 2\n'
+            '\n'
+            '- TaskB (1 failure)\n'
+            '\n'
+            '      error'
+        )
+
+    def test_include_two_expls(self):
+        bn = BatchNotifier(batch_mode='family', error_messages=2)
+        bn.add_failure('Task(a=1)', 'Task', {'a': 1}, 'error 1', [])
+        bn.add_failure('Task(a=2)', 'Task', {'a': 2}, 'error 2', [])
+        bn.add_failure('TaskB(a=1)', 'TaskB', {'a': 1}, 'error', [])
+
+        bn.send_email()
+        self.check_email_send(
+            'Luigi: 3 failures in the last 60 minutes',
+            '- Task (2 failures)\n'
+            '\n'
+            '      error 1\n'
+            '\n'
+            '      error 2\n'
+            '\n'
+            '- TaskB (1 failure)\n'
+            '\n'
+            '      error'
+        )
+
+    def test_limit_expl_length(self):
+        bn = BatchNotifier(batch_mode='family', error_messages=1, error_lines=2)
+        bn.add_failure('Task(a=1)', 'Task', {'a': '1'}, 'line 1\nline 2\nline 3\nline 4\n', [])
+        bn.send_email()
+        self.check_email_send(
+            'Luigi: 1 failure in the last 60 minutes',
+            '- Task (1 failure)\n'
+            '\n'
+            '      line 3\n'
+            '      line 4'
+        )
+
+    def test_expl_varies_by_owner(self):
+        bn = BatchNotifier(batch_mode='family', error_messages=1)
+        bn.add_failure('Task(a=1)', 'Task', {'a': '1'}, 'msg1', owners=['a@test.com'])
+        bn.add_failure('Task(a=2)', 'Task', {'a': '2'}, 'msg2', owners=['b@test.com'])
+        bn.send_email()
+        send_calls = [
+            mock.call(
+                'Luigi: Your tasks have 1 failure in the last 60 minutes',
+                '- Task (1 failure)\n'
+                '\n'
+                '      msg1',
+                'sender@test.com',
+                ('a@test.com',),
+            ),
+            mock.call(
+                'Luigi: Your tasks have 1 failure in the last 60 minutes',
+                '- Task (1 failure)\n'
+                '\n'
+                '      msg2',
+                'sender@test.com',
+                ('b@test.com',),
+            ),
+            mock.call(
+                'Luigi: 2 failures in the last 60 minutes',
+                '- Task (2 failures)\n'
+                '\n'
+                '      msg2',
+                'sender@test.com',
+                ('r@test.com',),
+            ),
+        ]
+        self.send_email.assert_has_calls(send_calls, any_order=True)
+
+    def test_include_two_expls_html_format(self):
+        self.email().format = 'html'
+        bn = BatchNotifier(batch_mode='family', error_messages=2)
+        bn.add_failure('Task(a=1)', 'Task', {'a': 1}, 'error 1', [])
+        bn.add_failure('Task(a=2)', 'Task', {'a': 2}, 'error 2', [])
+        bn.add_failure('TaskB(a=1)', 'TaskB', {'a': 1}, 'error', [])
+
+        bn.send_email()
+        self.check_email_send(
+            'Luigi: 3 failures in the last 60 minutes',
+            '<ul>\n'
+            '<li>Task (2 failures)\n'
+            '<pre>error 1</pre>\n'
+            '<pre>error 2</pre>\n'
+            '<li>TaskB (1 failure)\n'
+            '<pre>error</pre>\n'
+            '</ul>'
+        )
+
+    def test_limit_expl_length_html_format(self):
+        self.email().format = 'html'
+        bn = BatchNotifier(batch_mode='family', error_messages=1, error_lines=2)
+        bn.add_failure('Task(a=1)', 'Task', {'a': 1}, 'line 1\nline 2\nline 3\nline 4\n', [])
+        bn.send_email()
+        self.check_email_send(
+            'Luigi: 1 failure in the last 60 minutes',
+            '<ul>\n'
+            '<li>Task (1 failure)\n'
+            '<pre>line 3\n'
+            'line 4</pre>\n'
+            '</ul>'
+        )
+
+    def test_send_clears_backlog(self):
+        bn = BatchNotifier(batch_mode='all')
+        bn.add_failure('Task(a=5)', 'Task', {'a': 5}, 'error', [])
+        bn.add_disable('Task(a=5)', 'Task', {'a': 5}, [])
+        bn.add_scheduling_fail('Task(a=6)', 'Task', {'a': 6}, 'scheduling error', [])
+        bn.send_email()
+
+        self.send_email.reset_mock()
+        bn.send_email()
+        self.send_email.assert_not_called()
+
+    def test_send_clears_all_old_data(self):
+        bn = BatchNotifier(batch_mode='all', error_messages=100)
+
+        for i in range(100):
+            bn.add_failure('Task(a=5)', 'Task', {'a': 5}, 'error {}'.format(i), [])
+            bn.add_disable('Task(a=5)', 'Task', {'a': 5}, [])
+            bn.add_scheduling_fail('Task(a=6)', 'Task', {'a': 6}, 'scheduling error {}'.format(i), [])
+            bn.send_email()
+            self.check_email_send(
+                'Luigi: 1 failure, 1 disable, 1 scheduling failure in the last 60 minutes',
+                '- Task(a=5) (1 failure, 1 disable)\n'
+                '\n'
+                '      error {}\n'
+                '\n'
+                '- Task(a=6) (1 scheduling failure)\n'
+                '\n'
+                '      scheduling error {}'.format(i, i),
+            )
+            self.send_email.reset_mock()
+
+    def test_auto_send_on_update_after_time_period(self):
+        bn = BatchNotifier(batch_mode='all')
+        bn.add_failure('Task(a=5)', 'Task', {'a': 5}, 'error', [])
+
+        for i in range(60):
+            bn.update()
+            self.send_email.assert_not_called()
+            self.incr_time(minutes=1)
+
+        bn.update()
+        self.check_email_send(
+            'Luigi: 1 failure in the last 60 minutes',
+            '- Task(a=5) (1 failure)'
+        )
+
+    def test_auto_send_on_update_after_time_period_with_disable_only(self):
+        bn = BatchNotifier(batch_mode='all')
+        bn.add_disable('Task(a=5)', 'Task', {'a': 5}, [])
+
+        for i in range(60):
+            bn.update()
+            self.send_email.assert_not_called()
+            self.incr_time(minutes=1)
+
+        bn.update()
+        self.check_email_send(
+            'Luigi: 1 disable in the last 60 minutes',
+            '- Task(a=5) (1 disable)'
+        )
+
+    def test_no_auto_send_until_end_of_interval_with_error(self):
+        bn = BatchNotifier(batch_mode='all')
+
+        for i in range(90):
+            bn.update()
+            self.send_email.assert_not_called()
+            self.incr_time(minutes=1)
+
+        bn.add_failure('Task(a=5)', 'Task', {'a': 5}, 'error', [])
+        for i in range(30):
+            bn.update()
+            self.send_email.assert_not_called()
+            self.incr_time(minutes=1)
+
+        bn.update()
+        self.check_email_send(
+            'Luigi: 1 failure in the last 60 minutes',
+            '- Task(a=5) (1 failure)'
+        )
+
+    def test_send_batch_failure_emails_to_owners(self):
+        bn = BatchNotifier(batch_mode='all')
+        bn.add_failure('Task(a=1)', 'Task', {'a': '1'}, 'error', ['a@test.com', 'b@test.com'])
+        bn.add_failure('Task(a=1)', 'Task', {'a': '1'}, 'error', ['b@test.com'])
+        bn.add_failure('Task(a=2)', 'Task', {'a': '2'}, 'error', ['a@test.com'])
+        bn.send_email()
+
+        send_calls = [
+            mock.call(
+                'Luigi: 3 failures in the last 60 minutes',
+                '- Task(a=1) (2 failures)\n'
+                '- Task(a=2) (1 failure)',
+                'sender@test.com',
+                ('r@test.com',),
+            ),
+            mock.call(
+                'Luigi: Your tasks have 2 failures in the last 60 minutes',
+                '- Task(a=1) (1 failure)\n'
+                '- Task(a=2) (1 failure)',
+                'sender@test.com',
+                ('a@test.com',),
+            ),
+            mock.call(
+                'Luigi: Your tasks have 2 failures in the last 60 minutes',
+                '- Task(a=1) (2 failures)',
+                'sender@test.com',
+                ('b@test.com',),
+            ),
+        ]
+        self.send_email.assert_has_calls(send_calls, any_order=True)
+
+    def test_send_batch_disable_email_to_owners(self):
+        bn = BatchNotifier(batch_mode='all')
+        bn.add_disable('Task(a=1)', 'Task', {'a': '1'}, ['a@test.com'])
+        bn.send_email()
+
+        send_calls = [
+            mock.call(
+                'Luigi: 1 disable in the last 60 minutes',
+                '- Task(a=1) (1 disable)',
+                'sender@test.com',
+                ('r@test.com',),
+            ),
+            mock.call(
+                'Luigi: Your tasks have 1 disable in the last 60 minutes',
+                '- Task(a=1) (1 disable)',
+                'sender@test.com',
+                ('a@test.com',),
+            ),
+        ]
+        self.send_email.assert_has_calls(send_calls, any_order=True)
+
+    def test_batch_identical_expls(self):
+        bn = BatchNotifier(error_messages=1, group_by_error_messages=True)
+        bn.add_failure('Task(a=1)', 'Task', {'a': '1'}, 'msg1', [])
+        bn.add_failure('Task(a=2)', 'Task', {'a': '2'}, 'msg1', [])
+        bn.add_failure('Task(a=3)', 'Task', {'a': '3'}, 'msg1', [])
+        bn.add_failure('Task(a=4)', 'Task', {'a': '4'}, 'msg2', [])
+        bn.add_failure('Task(a=4)', 'Task', {'a': '4'}, 'msg2', [])
+        bn.send_email()
+        self.check_email_send(
+            'Luigi: 5 failures in the last 60 minutes',
+            '- Task(a=1) (1 failure)\n'
+            '  Task(a=2) (1 failure)\n'
+            '  Task(a=3) (1 failure)\n'
+            '\n'
+            '      msg1\n'
+            '\n'
+            '- Task(a=4) (2 failures)\n'
+            '\n'
+            '      msg2'
+        )
+
+    def test_batch_identical_expls_html(self):
+        self.email().format = 'html'
+        bn = BatchNotifier(error_messages=1, group_by_error_messages=True)
+        bn.add_failure('Task(a=1)', 'Task', {'a': '1'}, 'msg1', [])
+        bn.add_failure('Task(a=2)', 'Task', {'a': '2'}, 'msg1', [])
+        bn.add_failure('Task(a=3)', 'Task', {'a': '3'}, 'msg1', [])
+        bn.add_failure('Task(a=4)', 'Task', {'a': '4'}, 'msg2', [])
+        bn.add_failure('Task(a=4)', 'Task', {'a': '4'}, 'msg2', [])
+        bn.send_email()
+        self.check_email_send(
+            'Luigi: 5 failures in the last 60 minutes',
+            '<ul>\n'
+            '<li>Task(a=1) (1 failure)\n'
+            '<br>Task(a=2) (1 failure)\n'
+            '<br>Task(a=3) (1 failure)\n'
+            '<pre>msg1</pre>\n'
+            '<li>Task(a=4) (2 failures)\n'
+            '<pre>msg2</pre>\n'
+            '</ul>'
+        )
+
+    def test_unicode_error_message(self):
+        bn = BatchNotifier(error_messages=1)
+        bn.add_failure('Task()', 'Task', {}, six.u('Érror'), [])
+        bn.send_email()
+        self.check_email_send(
+            'Luigi: 1 failure in the last 60 minutes',
+            six.u(
+                '- Task() (1 failure)\n'
+                '\n'
+                '      Érror'
+            )
+        )
+
+    def test_unicode_error_message_html(self):
+        self.email().format = 'html'
+        bn = BatchNotifier(error_messages=1)
+        bn.add_failure('Task()', 'Task', {}, six.u('Érror'), [])
+        bn.send_email()
+        self.check_email_send(
+            'Luigi: 1 failure in the last 60 minutes',
+            six.u(
+                '<ul>\n'
+                '<li>Task() (1 failure)\n'
+                '<pre>Érror</pre>\n'
+                '</ul>'
+            ),
+        )
+
+    def test_unicode_param_value(self):
+        for batch_mode in ('all', 'unbatched_params'):
+            self.send_email.reset_mock()
+            bn = BatchNotifier(batch_mode=batch_mode)
+            bn.add_failure(six.u('Task(a=á)'), 'Task', {'a': six.u('á')}, 'error', [])
+            bn.send_email()
+            self.check_email_send(
+                'Luigi: 1 failure in the last 60 minutes',
+                six.u('- Task(a=á) (1 failure)')
+            )
+
+    def test_unicode_param_value_html(self):
+        self.email().format = 'html'
+        for batch_mode in ('all', 'unbatched_params'):
+            self.send_email.reset_mock()
+            bn = BatchNotifier(batch_mode=batch_mode)
+            bn.add_failure(six.u('Task(a=á)'), 'Task', {'a': six.u('á')}, 'error', [])
+            bn.send_email()
+            self.check_email_send(
+                'Luigi: 1 failure in the last 60 minutes',
+                six.u(
+                    '<ul>\n'
+                    '<li>Task(a=á) (1 failure)\n'
+                    '</ul>'
+                )
+            )
+
+    def test_unicode_param_name(self):
+        for batch_mode in ('all', 'unbatched_params'):
+            self.send_email.reset_mock()
+            bn = BatchNotifier(batch_mode=batch_mode)
+            bn.add_failure(six.u('Task(á=a)'), 'Task', {six.u('á'): 'a'}, 'error', [])
+            bn.send_email()
+            self.check_email_send(
+                'Luigi: 1 failure in the last 60 minutes',
+                six.u('- Task(á=a) (1 failure)')
+            )
+
+    def test_unicode_param_name_html(self):
+        self.email().format = 'html'
+        for batch_mode in ('all', 'unbatched_params'):
+            self.send_email.reset_mock()
+            bn = BatchNotifier(batch_mode=batch_mode)
+            bn.add_failure(six.u('Task(á=a)'), 'Task', {six.u('á'): 'a'}, 'error', [])
+            bn.send_email()
+            self.check_email_send(
+                'Luigi: 1 failure in the last 60 minutes',
+                six.u(
+                    '<ul>\n'
+                    '<li>Task(á=a) (1 failure)\n'
+                    '</ul>'
+                )
+            )
+
+    def test_unicode_class_name(self):
+        bn = BatchNotifier()
+        bn.add_failure(six.u('Tásk()'), six.u('Tásk'), {}, 'error', [])
+        bn.send_email()
+        self.check_email_send(
+            'Luigi: 1 failure in the last 60 minutes',
+            six.u('- Tásk() (1 failure)')
+        )
+
+    def test_unicode_class_name_html(self):
+        self.email().format = 'html'
+        bn = BatchNotifier()
+        bn.add_failure(six.u('Tásk()'), six.u('Tásk'), {}, 'error', [])
+        bn.send_email()
+        self.check_email_send(
+            'Luigi: 1 failure in the last 60 minutes',
+            six.u(
+                '<ul>\n'
+                '<li>Tásk() (1 failure)\n'
+                '</ul>'
+            ),
+        )

--- a/test/scheduler_api_test.py
+++ b/test/scheduler_api_test.py
@@ -16,6 +16,7 @@
 #
 
 import itertools
+import mock
 import time
 from helpers import unittest
 from nose.plugins.attrib import attr
@@ -1763,3 +1764,209 @@ class SchedulerApiTest(unittest.TestCase):
         self.sch.prune()
         self.assertEqual({'B'}, set(self.sch.task_list(RUNNING, '')))
         self.assertEqual({'B'}, set(self.sch.task_list('', '')))
+
+    @mock.patch('luigi.scheduler.BatchNotifier')
+    def test_batch_failure_emails(self, BatchNotifier):
+        scheduler = Scheduler(batch_emails=True)
+        scheduler.add_task(
+            worker=WORKER, status=FAILED, task_id='T(a=5, b=6)', family='T',
+            params={'a': '5', 'b': '6'}, expl='"bad thing"')
+        BatchNotifier().add_failure.assert_called_once_with(
+            'T(a=5, b=6)',
+            'T',
+            {'a': '5', 'b': '6'},
+            'bad thing',
+            None,
+        )
+        BatchNotifier().add_disable.assert_not_called()
+
+    @mock.patch('luigi.scheduler.BatchNotifier')
+    def test_send_batch_email_on_dump(self, BatchNotifier):
+        scheduler = Scheduler(batch_emails=True)
+
+        BatchNotifier().send_email.assert_not_called()
+        scheduler.dump()
+        BatchNotifier().send_email.assert_called_once_with()
+
+    @mock.patch('luigi.scheduler.BatchNotifier')
+    def test_do_not_send_batch_email_on_dump_without_batch_enabled(self, BatchNotifier):
+        scheduler = Scheduler(batch_emails=False)
+        scheduler.dump()
+
+        BatchNotifier().send_email.assert_not_called()
+
+    @mock.patch('luigi.scheduler.BatchNotifier')
+    def test_handle_bad_expl_in_failure_emails(self, BatchNotifier):
+        scheduler = Scheduler(batch_emails=True)
+        scheduler.add_task(
+            worker=WORKER, status=FAILED, task_id='T(a=5, b=6)', family='T',
+            params={'a': '5', 'b': '6'}, expl='bad thing')
+        BatchNotifier().add_failure.assert_called_once_with(
+            'T(a=5, b=6)',
+            'T',
+            {'a': '5', 'b': '6'},
+            'bad thing',
+            None,
+        )
+        BatchNotifier().add_disable.assert_not_called()
+
+    @mock.patch('luigi.scheduler.BatchNotifier')
+    def test_scheduling_failure(self, BatchNotifier):
+        scheduler = Scheduler(batch_emails=True)
+        scheduler.announce_scheduling_failure(
+            worker=WORKER,
+            task_name='T(a=1, b=2)',
+            family='T',
+            params={'a': '1', 'b': '2'},
+            expl='error',
+            owners=('owner',)
+        )
+        BatchNotifier().add_scheduling_fail.assert_called_once_with(
+            'T(a=1, b=2)', 'T', {'a': '1', 'b': '2'}, 'error', ('owner',))
+
+    @mock.patch('luigi.scheduler.BatchNotifier')
+    def test_scheduling_failure_without_batcher(self, BatchNotifier):
+        scheduler = Scheduler(batch_emails=False)
+        scheduler.announce_scheduling_failure(
+            worker=WORKER,
+            task_name='T(a=1, b=2)',
+            family='T',
+            params={'a': '1', 'b': '2'},
+            expl='error',
+            owners=('owner',)
+        )
+        BatchNotifier().add_scheduling_fail.assert_not_called()
+
+    @mock.patch('luigi.scheduler.BatchNotifier')
+    def test_batch_failure_emails_with_task_batcher(self, BatchNotifier):
+        scheduler = Scheduler(batch_emails=True)
+        scheduler.add_task_batcher(worker=WORKER, task_family='T', batched_args=['a'])
+        scheduler.add_task(
+            worker=WORKER, status=FAILED, task_id='T(a=5, b=6)', family='T',
+            params={'a': '5', 'b': '6'}, expl='"bad thing"')
+        BatchNotifier().add_failure.assert_called_once_with(
+            'T(a=5, b=6)',
+            'T',
+            {'b': '6'},
+            'bad thing',
+            None,
+        )
+        BatchNotifier().add_disable.assert_not_called()
+
+    @mock.patch('luigi.scheduler.BatchNotifier')
+    def test_scheduling_failure_with_task_batcher(self, BatchNotifier):
+        scheduler = Scheduler(batch_emails=True)
+        scheduler.add_task_batcher(worker=WORKER, task_family='T', batched_args=['a'])
+        scheduler.announce_scheduling_failure(
+            worker=WORKER,
+            task_name='T(a=1, b=2)',
+            family='T',
+            params={'a': '1', 'b': '2'},
+            expl='error',
+            owners=('owner',)
+        )
+        BatchNotifier().add_scheduling_fail.assert_called_once_with(
+            'T(a=1, b=2)', 'T', {'b': '2'}, 'error', ('owner',))
+
+    @mock.patch('luigi.scheduler.BatchNotifier')
+    def test_batch_failure_email_with_owner(self, BatchNotifier):
+        scheduler = Scheduler(batch_emails=True)
+        scheduler.add_task(
+            worker=WORKER, status=FAILED, task_id='T(a=5, b=6)', family='T',
+            params={'a': '5', 'b': '6'}, expl='"bad thing"', owners=['a@test.com', 'b@test.com'])
+        BatchNotifier().add_failure.assert_called_once_with(
+            'T(a=5, b=6)',
+            'T',
+            {'a': '5', 'b': '6'},
+            'bad thing',
+            ['a@test.com', 'b@test.com'],
+        )
+        BatchNotifier().add_disable.assert_not_called()
+
+    @mock.patch('luigi.scheduler.notifications')
+    @mock.patch('luigi.scheduler.BatchNotifier')
+    def test_batch_disable_emails(self, BatchNotifier, notifications):
+        scheduler = Scheduler(batch_emails=True, retry_count=1)
+        scheduler.add_task(
+            worker=WORKER, status=FAILED, task_id='T(a=5, b=6)', family='T',
+            params={'a': '5', 'b': '6'}, expl='"bad thing"')
+        BatchNotifier().add_failure.assert_called_once_with(
+            'T(a=5, b=6)',
+            'T',
+            {'a': '5', 'b': '6'},
+            'bad thing',
+            None,
+        )
+        BatchNotifier().add_disable.assert_called_once_with(
+            'T(a=5, b=6)',
+            'T',
+            {'a': '5', 'b': '6'},
+            None,
+        )
+        notifications.send_error_email.assert_not_called()
+
+    @mock.patch('luigi.scheduler.notifications')
+    @mock.patch('luigi.scheduler.BatchNotifier')
+    def test_batch_disable_email_with_owner(self, BatchNotifier, notifications):
+        scheduler = Scheduler(batch_emails=True, retry_count=1)
+        scheduler.add_task(
+            worker=WORKER, status=FAILED, task_id='T(a=5, b=6)', family='T',
+            params={'a': '5', 'b': '6'}, expl='"bad thing"', owners=['a@test.com'])
+        BatchNotifier().add_failure.assert_called_once_with(
+            'T(a=5, b=6)',
+            'T',
+            {'a': '5', 'b': '6'},
+            'bad thing',
+            ['a@test.com'],
+        )
+        BatchNotifier().add_disable.assert_called_once_with(
+            'T(a=5, b=6)',
+            'T',
+            {'a': '5', 'b': '6'},
+            ['a@test.com'],
+        )
+        notifications.send_error_email.assert_not_called()
+
+    @mock.patch('luigi.scheduler.notifications')
+    @mock.patch('luigi.scheduler.BatchNotifier')
+    def test_batch_disable_emails_with_task_batcher(self, BatchNotifier, notifications):
+        scheduler = Scheduler(batch_emails=True, retry_count=1)
+        scheduler.add_task_batcher(worker=WORKER, task_family='T', batched_args=['a'])
+        scheduler.add_task(
+            worker=WORKER, status=FAILED, task_id='T(a=5, b=6)', family='T',
+            params={'a': '5', 'b': '6'}, expl='"bad thing"')
+        BatchNotifier().add_failure.assert_called_once_with(
+            'T(a=5, b=6)',
+            'T',
+            {'b': '6'},
+            'bad thing',
+            None,
+        )
+        BatchNotifier().add_disable.assert_called_once_with(
+            'T(a=5, b=6)',
+            'T',
+            {'b': '6'},
+            None,
+        )
+        notifications.send_error_email.assert_not_called()
+
+    @mock.patch('luigi.scheduler.notifications')
+    def test_send_normal_disable_email(self, notifications):
+        scheduler = Scheduler(batch_emails=False, retry_count=1)
+        notifications.send_error_email.assert_not_called()
+        scheduler.add_task(
+            worker=WORKER, status=FAILED, task_id='T(a=5, b=6)', family='T',
+            params={'a': '5', 'b': '6'}, expl='"bad thing"')
+        self.assertEqual(1, notifications.send_error_email.call_count)
+
+    @mock.patch('luigi.scheduler.BatchNotifier')
+    def test_no_batch_notifier_without_batch_emails(self, BatchNotifier):
+        Scheduler(batch_emails=False)
+        BatchNotifier.assert_not_called()
+
+    @mock.patch('luigi.scheduler.BatchNotifier')
+    def test_update_batcher_on_prune(self, BatchNotifier):
+        scheduler = Scheduler(batch_emails=True)
+        BatchNotifier().update.assert_not_called()
+        scheduler.prune()
+        BatchNotifier().update.assert_called_once_with()

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -1129,6 +1129,48 @@ class WorkerEmailTest(LuigiTestCase):
         self.assertTrue(emails[0].find("Luigi: %s failed scheduling" % (a,)) != -1)
         self.assertFalse(a.has_run)
 
+    @with_config({'batch_email': {'email_interval': '0'}, 'worker': {'send_failure_email': 'False'}})
+    @email_patch
+    def test_complete_error_email_batch(self, emails):
+        class A(DummyTask):
+            def complete(self):
+                raise Exception("b0rk")
+
+        scheduler = Scheduler(batch_emails=True)
+        worker = Worker(scheduler)
+        a = A()
+        self.assertEqual(emails, [])
+        worker.add(a)
+        self.assertEqual(emails, [])
+        worker.run()
+        self.assertEqual(emails, [])
+        self.assertFalse(a.has_run)
+        scheduler.prune()
+        self.assertTrue("1 scheduling failure" in emails[0])
+
+    @with_config({'batch_email': {'email_interval': '0'}, 'worker': {'send_failure_email': 'False'}})
+    @email_patch
+    def test_complete_error_email_batch_to_owner(self, emails):
+        class A(DummyTask):
+            owner_email = 'a_owner@test.com'
+
+            def complete(self):
+                raise Exception("b0rk")
+
+        scheduler = Scheduler(batch_emails=True)
+        worker = Worker(scheduler)
+        a = A()
+        self.assertEqual(emails, [])
+        worker.add(a)
+        self.assertEqual(emails, [])
+        worker.run()
+        self.assertEqual(emails, [])
+        self.assertFalse(a.has_run)
+        scheduler.prune()
+        self.assertTrue(any(
+            "1 scheduling failure" in email and 'a_owner@test.com' in email
+            for email in emails))
+
     @email_patch
     def test_requires_error(self, emails):
         class A(DummyTask):
@@ -1142,6 +1184,25 @@ class WorkerEmailTest(LuigiTestCase):
         self.assertTrue(emails[0].find("Luigi: %s failed scheduling" % (a,)) != -1)
         self.worker.run()
         self.assertFalse(a.has_run)
+
+    @with_config({'batch_email': {'email_interval': '0'}, 'worker': {'send_failure_email': 'False'}})
+    @email_patch
+    def test_requires_error_email_batch(self, emails):
+        class A(DummyTask):
+
+            def requires(self):
+                raise Exception("b0rk")
+
+        scheduler = Scheduler(batch_emails=True)
+        worker = Worker(scheduler)
+        a = A()
+        self.assertEqual(emails, [])
+        worker.add(a)
+        self.assertEqual(emails, [])
+        worker.run()
+        self.assertFalse(a.has_run)
+        scheduler.prune()
+        self.assertTrue("1 scheduling failure" in emails[0])
 
     @email_patch
     def test_complete_return_value(self, emails):
@@ -1158,6 +1219,26 @@ class WorkerEmailTest(LuigiTestCase):
         self.assertTrue(emails[0].find("Luigi: %s failed scheduling" % (a,)) != -1)
         self.assertFalse(a.has_run)
 
+    @with_config({'batch_email': {'email_interval': '0'}, 'worker': {'send_failure_email': 'False'}})
+    @email_patch
+    def test_complete_return_value_email_batch(self, emails):
+        class A(DummyTask):
+
+            def complete(self):
+                pass  # no return value should be an error
+
+        scheduler = Scheduler(batch_emails=True)
+        worker = Worker(scheduler)
+        a = A()
+        self.assertEqual(emails, [])
+        worker.add(a)
+        self.assertEqual(emails, [])
+        self.worker.run()
+        self.assertEqual(emails, [])
+        self.assertFalse(a.has_run)
+        scheduler.prune()
+        self.assertTrue("1 scheduling failure" in emails[0])
+
     @email_patch
     def test_run_error(self, emails):
         class A(luigi.Task):
@@ -1165,17 +1246,66 @@ class WorkerEmailTest(LuigiTestCase):
                 raise Exception("b0rk")
 
         a = A()
-        self.worker.add(a)
-        self.assertEqual(emails, [])
-        self.worker.run()
+        luigi.build([a], workers=1, local_scheduler=True)
+        self.assertEqual(1, len(emails))
         self.assertTrue(emails[0].find("Luigi: %s FAILED" % (a,)) != -1)
 
+    @with_config({'batch_email': {'email_interval': '0'}, 'worker': {'send_failure_email': 'False'}})
     @email_patch
-    def test_task_process_dies(self, emails):
+    def test_run_error_email_batch(self, emails):
+        class A(luigi.Task):
+            owner_email = ['a@test.com', 'b@test.com']
+
+            def run(self):
+                raise Exception("b0rk")
+        scheduler = Scheduler(batch_emails=True)
+        worker = Worker(scheduler)
+        worker.add(A())
+        worker.run()
+        scheduler.prune()
+        self.assertEqual(3, len(emails))
+        self.assertTrue(any('a@test.com' in email for email in emails))
+        self.assertTrue(any('b@test.com' in email for email in emails))
+
+    @with_config({'batch_email': {'email_interval': '0'}, 'worker': {'send_failure_email': 'False'}})
+    @email_patch
+    def test_run_error_batch_email_string(self, emails):
+        class A(luigi.Task):
+            owner_email = 'a@test.com'
+
+            def run(self):
+                raise Exception("b0rk")
+        scheduler = Scheduler(batch_emails=True)
+        worker = Worker(scheduler)
+        worker.add(A())
+        worker.run()
+        scheduler.prune()
+        self.assertEqual(2, len(emails))
+        self.assertTrue(any('a@test.com' in email for email in emails))
+
+    @with_config({'worker': {'send_failure_email': 'False'}})
+    @email_patch
+    def test_run_error_no_email(self, emails):
+        class A(luigi.Task):
+            def run(self):
+                raise Exception("b0rk")
+
+        luigi.build([A()], workers=1, local_scheduler=True)
+        self.assertFalse(emails)
+
+    @email_patch
+    def test_task_process_dies_with_email(self, emails):
         a = SendSignalTask(signal.SIGKILL)
         luigi.build([a], workers=2, local_scheduler=True)
+        self.assertEqual(1, len(emails))
         self.assertTrue(emails[0].find("Luigi: %s FAILED" % (a,)) != -1)
         self.assertTrue(emails[0].find("died unexpectedly with exit code -9") != -1)
+
+    @with_config({'worker': {'send_failure_email': 'False'}})
+    @email_patch
+    def test_task_process_dies_no_email(self, emails):
+        luigi.build([SendSignalTask(signal.SIGKILL)], workers=2, local_scheduler=True)
+        self.assertEqual([], emails)
 
     @email_patch
     def test_task_times_out(self, emails):
@@ -1187,8 +1317,21 @@ class WorkerEmailTest(LuigiTestCase):
 
         a = A()
         luigi.build([a], workers=2, local_scheduler=True)
+        self.assertEqual(1, len(emails))
         self.assertTrue(emails[0].find("Luigi: %s FAILED" % (a,)) != -1)
         self.assertTrue(emails[0].find("timed out after 0.0001 seconds and was terminated.") != -1)
+
+    @with_config({'worker': {'send_failure_email': 'False'}})
+    @email_patch
+    def test_task_times_out_no_email(self, emails):
+        class A(luigi.Task):
+            worker_timeout = 0.0001
+
+            def run(self):
+                time.sleep(5)
+
+        luigi.build([A()], workers=2, local_scheduler=True)
+        self.assertEqual([], emails)
 
     @with_config(dict(worker=dict(retry_external_tasks='true')))
     @email_patch


### PR DESCRIPTION
Recreated from original PR: https://github.com/spotify/luigi/pull/1916

## Description
Enables sending periodic batch e-mails from the scheduler rather than sending immediate failure/disable/scheduling failure e-mails on every event.

## Motivation and Context
With a large pipeline, it's fairly easy to get hundreds of e-mails an hour when something goes wrong. This translates to thousands of e-mails per day. While this is a great resource for tracking down error messages of a particular task in your e-mail history, it's not nearly as great for understanding what...